### PR TITLE
Fix encoding of all struct attributes

### DIFF
--- a/avro.go
+++ b/avro.go
@@ -218,6 +218,13 @@ func (c *Codec) encodeUnionHook(k reflect.Kind, data interface{}) (interface{}, 
 		return map[string]interface{}{typeName: pointed.Interface()}, nil
 	}
 
+	if k == reflect.Struct {
+		s := structs.New(data)
+		s.TagName = "avro"
+		s.EncodeHook = c.encodeUnionHook
+		return s.Map(), nil
+	}
+
 	if value.Kind() == reflect.Slice && value.Len() > 0 && value.Index(0).Kind() == reflect.Struct {
 		var ret []interface{}
 		for i := 0; i < value.Len(); i++ {
@@ -233,6 +240,7 @@ func (c *Codec) encodeUnionHook(k reflect.Kind, data interface{}) (interface{}, 
 		value = convertToBaseType(value)
 		return value.Interface(), nil
 	}
+
 	return data, nil
 }
 

--- a/avro_test.go
+++ b/avro_test.go
@@ -898,6 +898,57 @@ func TestCodec_Marshal_enum(t *testing.T) {
 	require.Equal(t, expected, decoded)
 }
 
+func TestCodec_Marshal_struct_with_union(t *testing.T) {
+	schema := `{
+      "type": "record",
+      "name": "event",
+      "fields": [
+        {
+          "name": "my_struct",
+          "type": {
+            "type": "record",
+            "name": "my_struct_record",
+            "fields": [
+              {
+                "name": "optional_string_id",
+                "type": ["null", "string"],
+                "default": null
+              }
+            ]
+          }
+        }
+      ]
+    }`
+
+	codec, err := NewCodec(schema)
+	require.NoError(t, err)
+
+	type MyStruct struct {
+		OptionalStringID *string `avro:"optional_string_id"`
+	}
+
+	type StructEvent struct {
+		MyStruct MyStruct `avro:"my_struct"`
+	}
+
+	expected := StructEvent{
+		MyStruct: MyStruct{
+			OptionalStringID: func(s string) *string {
+				return &s
+			}("foo"),
+		},
+	}
+
+	avro, err := codec.Marshal(expected)
+	if assert.NoError(t, err) {
+		var decoded StructEvent
+
+		err = codec.Unmarshal(avro, &decoded)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, decoded)
+	}
+}
+
 func Test_convertToBaseType(t *testing.T) {
 	type A string
 	type B A


### PR DESCRIPTION
Members of a struct are not encoded in native avro format.
It works with simple/basic attributes because no conversion are
needed, but fails with composed attributes or non-standard avro type.

Exemple with this simple schema:

    {
      "type": "record",
      "name": "event",
      "fields": [
        {
          "name": "my_struct",
          "type": {
            "type": "record",
            "name": "my_struct_record",
            "fields": [
              {
                "name": "optional_string_id",
                "type": ["null", "string"],
                "default": null
              }
            ]
          }
        }
      ]
    }

Expected encoding result:

    {
      "my_struct": {
        "optional_string_id": {
          "string": "foo"
        }
      }
    }

Result we had:

    {
      "my_struct": {
        "optional_string_id": "foo"
      }
    }

solve #15 